### PR TITLE
Adding support to Custom Aggregation Methods

### DIFF
--- a/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
+++ b/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
@@ -1602,6 +1602,9 @@
     <Compile Include="..\UriParser\SemanticAst\CollectionResourceNode.cs">
       <Link>Microsoft\OData\Core\UriParser\SemanticAst\CollectionResourceNode.cs</Link>
     </Compile>
+    <Compile Include="..\UriParser\SemanticAst\CountVirtualPropertyNode.cs">
+      <Link>Microsoft\OData\Core\UriParser\SemanticAst\CountVirtualPropertyNode.cs</Link>
+    </Compile>
     <Compile Include="..\UriParser\SemanticAst\NonResourceRangeVariable.cs">
       <Link>Microsoft\OData\Core\UriParser\SemanticAst\NonResourceRangeVariable.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -609,7 +609,7 @@ namespace Microsoft.OData {
         internal const string UriQueryExpressionParser_RangeVariableAlreadyDeclared = "UriQueryExpressionParser_RangeVariableAlreadyDeclared";
         internal const string UriQueryExpressionParser_AsExpected = "UriQueryExpressionParser_AsExpected";
         internal const string UriQueryExpressionParser_WithExpected = "UriQueryExpressionParser_WithExpected";
-        internal const string UriQueryExpressionParser_UnrecognizedWithVerb = "UriQueryExpressionParser_UnrecognizedWithVerb";
+        internal const string UriQueryExpressionParser_UnrecognizedWithMethod = "UriQueryExpressionParser_UnrecognizedWithMethod";
         internal const string UriQueryExpressionParser_PropertyPathExpected = "UriQueryExpressionParser_PropertyPathExpected";
         internal const string UriQueryExpressionParser_KeywordOrIdentifierExpected = "UriQueryExpressionParser_KeywordOrIdentifierExpected";
         internal const string UriQueryPathParser_RequestUriDoesNotHaveTheCorrectBaseUri = "UriQueryPathParser_RequestUriDoesNotHaveTheCorrectBaseUri";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -68,6 +68,7 @@
     <Compile Include="BindingPathHelper.cs" />
     <Compile Include="UriParser\ODataPathInfo.cs" />
     <Compile Include="UriParser\SemanticAst\CollectionComplexNode.cs" />
+    <Compile Include="UriParser\SemanticAst\CountVirtualPropertyNode.cs" />
     <Compile Include="UriParser\SemanticAst\SingleComplexNode.cs" />
     <Compile Include="UriParser\SemanticAst\SingleResourceNode.cs" />
     <Compile Include="UriParser\TypeFacetsPromotionRules.cs" />

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -661,7 +661,7 @@ UriQueryExpressionParser_CannotCreateStarTokenFromNonStar=Expecting a Star token
 UriQueryExpressionParser_RangeVariableAlreadyDeclared=The range variable '{0}' has already been declared.
 UriQueryExpressionParser_AsExpected='as' expected at position {0} in '{1}'.
 UriQueryExpressionParser_WithExpected='with' expected at position {0} in '{1}'.
-UriQueryExpressionParser_UnrecognizedWithVerb=Unrecognized with '{0}' at '{1}' in '{2}'.
+UriQueryExpressionParser_UnrecognizedWithMethod=Unrecognized with '{0}' at '{1}' in '{2}'.
 UriQueryExpressionParser_PropertyPathExpected=Expression expected at position {0} in '{1}'.
 UriQueryExpressionParser_KeywordOrIdentifierExpected='{0}' expected at position {1} in '{2}'.
 

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -4154,8 +4154,8 @@ namespace Microsoft.OData {
         /// <summary>
         /// A string like "Unrecognized with '{0}' at '{1}' in '{2}'."
         /// </summary>
-        internal static string UriQueryExpressionParser_UnrecognizedWithVerb(object p0, object p1, object p2) {
-            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.UriQueryExpressionParser_UnrecognizedWithVerb, p0, p1, p2);
+        internal static string UriQueryExpressionParser_UnrecognizedWithMethod(object p0, object p1, object p2) {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.UriQueryExpressionParser_UnrecognizedWithMethod, p0, p1, p2);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/PropertyCacheHandler.cs
+++ b/src/Microsoft.OData.Core/PropertyCacheHandler.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text;
 using Microsoft.OData.Edm;
 
 namespace Microsoft.OData
@@ -31,18 +32,21 @@ namespace Microsoft.OData
 
         public PropertySerializationInfo GetProperty(string name, IEdmStructuredType owningType)
         {
-            string uniqueName;
-            if (this.currentResourceScopeLevel == this.resourceSetScopeLevel + 1)
+            StringBuilder uniqueName = new StringBuilder();
+            if (owningType != null)
             {
-                uniqueName = name;
-            }
-            else
-            {
-                // To avoid the property name conflicts of single navigation property and navigation source
-                uniqueName = name + (this.currentResourceScopeLevel - this.resourceSetScopeLevel);
+                uniqueName.Append(owningType.FullTypeName());
+                uniqueName.Append("-");
             }
 
-            return this.currentPropertyCache.GetProperty(name, uniqueName, owningType);
+            uniqueName.Append(name);
+            if (this.currentResourceScopeLevel != this.resourceSetScopeLevel + 1)
+            {
+                // To avoid the property name conflicts of single navigation property and navigation source
+                uniqueName.Append(this.currentResourceScopeLevel - this.resourceSetScopeLevel);
+            }
+
+            return this.currentPropertyCache.GetProperty(name, uniqueName.ToString(), owningType);
         }
 
         public void SetCurrentResourceScopeLevel(int level)

--- a/src/Microsoft.OData.Core/Uri/ExpressionConstants.cs
+++ b/src/Microsoft.OData.Core/Uri/ExpressionConstants.cs
@@ -51,6 +51,9 @@ namespace Microsoft.OData
         /// <summary>',' constant to represent an value list separator.</summary>
         internal const string SymbolComma = ",";
 
+        /// <summary>'.' constant to represent the value of a dot separator.</summary>
+        internal const string SymbolDot = ".";
+
         /// <summary>'/' constant to represent the forward slash used in a query.</summary>
         internal const string SymbolForwardSlash = "/";
 

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/AggregateExpression.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/AggregateExpression.cs
@@ -16,6 +16,8 @@ namespace Microsoft.OData.UriParser.Aggregation
     {
         private readonly AggregationMethod method;
 
+        private readonly AggregationMethodDefinition methodDefinition;
+
         private readonly SingleValueNode expression;
 
         private readonly string alias;
@@ -42,6 +44,19 @@ namespace Microsoft.OData.UriParser.Aggregation
         }
 
         /// <summary>
+        /// Create a AggregateExpression.
+        /// </summary>
+        /// <param name="expression">The aggregation expression.</param>
+        /// <param name="methodDefinition">The <see cref="AggregationMethodDefinition"/>.</param>
+        /// <param name="alias">The aggregation alias.</param>
+        /// <param name="typeReference">The <see cref="IEdmTypeReference"/> of this aggregate expression.</param>
+        public AggregateExpression(SingleValueNode expression, AggregationMethodDefinition methodDefinition, string alias, IEdmTypeReference typeReference)
+            : this(expression, methodDefinition.MethodKind, alias, typeReference)
+        {
+            this.methodDefinition = methodDefinition;
+        }
+
+        /// <summary>
         /// Gets the aggregation expression.
         /// </summary>
         public SingleValueNode Expression
@@ -60,6 +75,17 @@ namespace Microsoft.OData.UriParser.Aggregation
             get
             {
                 return method;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="AggregationMethodDefinition"/>.
+        /// </summary>
+        public AggregationMethodDefinition MethodDefinition
+        {
+            get
+            {
+                return methodDefinition;
             }
         }
 

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/AggregateExpressionToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/AggregateExpressionToken.cs
@@ -20,16 +20,24 @@ namespace Microsoft.OData.UriParser.Aggregation
 
         private readonly AggregationMethod method;
 
+        private readonly AggregationMethodDefinition methodDefinition;
+
         private readonly string alias;
 
-        public AggregateExpressionToken(QueryToken expression, AggregationMethod withVerb, string alias)
+        public AggregateExpressionToken(QueryToken expression, AggregationMethod method, string alias)
         {
             ExceptionUtils.CheckArgumentNotNull(expression, "expression");
             ExceptionUtils.CheckArgumentNotNull(alias, "alias");
 
             this.expression = expression;
-            this.method = withVerb;
+            this.method = method;
             this.alias = alias;
+        }
+
+        public AggregateExpressionToken(QueryToken expression, AggregationMethodDefinition methodDefinition, string alias)
+            : this(expression, methodDefinition.MethodKind, alias)
+        {
+            this.methodDefinition = methodDefinition;
         }
 
         public override QueryTokenKind Kind
@@ -40,6 +48,11 @@ namespace Microsoft.OData.UriParser.Aggregation
         public AggregationMethod Method
         {
             get { return this.method; }
+        }
+
+        public AggregationMethodDefinition MethodDefinition
+        {
+            get { return this.methodDefinition; }
         }
 
         public QueryToken Expression

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/AggregationMethod.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/AggregationMethod.cs
@@ -34,6 +34,12 @@ namespace Microsoft.OData.UriParser.Aggregation
         /// <summary>
         /// The aggregation method CountDistinct.
         /// </summary>
-        CountDistinct
+        CountDistinct,
+
+        /// <summary>
+        /// The aggregation method Count.
+        /// Used only internally to represent the virtual property $count.
+        /// </summary>
+        VirtualPropertyCount,
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/AggregationMethod.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/AggregationMethod.cs
@@ -4,6 +4,8 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using System.Diagnostics;
+
 namespace Microsoft.OData.UriParser.Aggregation
 {
     /// <summary>
@@ -11,35 +13,77 @@ namespace Microsoft.OData.UriParser.Aggregation
     /// </summary>
     public enum AggregationMethod
     {
-        /// <summary>
-        /// The aggregation method Sum.
-        /// </summary>
+        /// <summary>The aggregation method Sum.</summary>
         Sum,
 
-        /// <summary>
-        /// The aggregation method Min.
-        /// </summary>
+        /// <summary>The aggregation method Min.</summary>
         Min,
 
-        /// <summary>
-        /// The aggregation method Max.
-        /// </summary>
+        /// <summary>The aggregation method Max.</summary>
         Max,
 
-        /// <summary>
-        /// The aggregation method Average.
-        /// </summary>
+        /// <summary>The aggregation method Average.</summary>
         Average,
 
-        /// <summary>
-        /// The aggregation method CountDistinct.
-        /// </summary>
+        /// <summary>The aggregation method CountDistinct.</summary>
         CountDistinct,
 
-        /// <summary>
-        /// The aggregation method Count.
-        /// Used only internally to represent the virtual property $count.
-        /// </summary>
+        /// <summary>The aggregation method Count. Used only internally to represent the virtual property $count.</summary>
         VirtualPropertyCount,
+
+        /// <summary>A custom aggregation method.</summary>
+        Custom
+    }
+
+    /// <summary>
+    /// Class that encapsulates all the information needed to define a aggregation method.
+    /// </summary>
+    public sealed class AggregationMethodDefinition
+    {
+        /// <summary>Returns a definition for the sum aggregation method.</summary>
+        public static AggregationMethodDefinition Sum = new AggregationMethodDefinition(AggregationMethod.Sum);
+
+        /// <summary>Returns a definition for the min aggregation method.</summary>
+        public static AggregationMethodDefinition Min = new AggregationMethodDefinition(AggregationMethod.Min);
+
+        /// <summary>Returns a definition for the max aggregation method.</summary>
+        public static AggregationMethodDefinition Max = new AggregationMethodDefinition(AggregationMethod.Max);
+
+        /// <summary>Returns a definition for the average aggregation method.</summary>
+        public static AggregationMethodDefinition Average = new AggregationMethodDefinition(AggregationMethod.Average);
+
+        /// <summary>Returns a definition for the countdistinct aggregation method.</summary>
+        public static AggregationMethodDefinition CountDistinct = new AggregationMethodDefinition(AggregationMethod.CountDistinct);
+
+        /// <summary>Returns a definition for the aggregation method used to calculate $count.</summary>
+        public static AggregationMethodDefinition VirtualPropertyCount = new AggregationMethodDefinition(AggregationMethod.VirtualPropertyCount);
+
+        /// <summary>Private constructor. Instances should be aquired via static fields of via Custom method.</summary>
+        /// <param name="aggregationMethodType">The <see cref="AggregationMethod"/> of this method definition.</param>
+        private AggregationMethodDefinition(AggregationMethod aggregationMethodType)
+        {
+            this.MethodKind = aggregationMethodType;
+        }
+
+        /// <summary>Returns the <see cref="AggregationMethod"/> of this method definition.</summary>
+        public AggregationMethod MethodKind { get; private set; }
+
+        /// <summary>Returns the label of this method definition.</summary>
+        public string MethodLabel { get; private set; }
+
+        /// <summary>Creates a custom method definition from it's label.</summary>
+        /// <param name="customMethodLabel">The label to call the custom method definition.</param>
+        /// <returns>The custom method created.</returns>
+        public static AggregationMethodDefinition Custom(string customMethodLabel)
+        {
+            ExceptionUtils.CheckArgumentNotNull(customMethodLabel, "customMethodLabel");
+
+            // Custom aggregation methods MUST use a namespace-qualified name (see [OData-ABNF]), i.e. contain at least one dot.
+            Debug.Assert(customMethodLabel.Contains(OData.ExpressionConstants.SymbolDot));
+
+            var aggregationMethod = new AggregationMethodDefinition(AggregationMethod.Custom);
+            aggregationMethod.MethodLabel = customMethodLabel;
+            return aggregationMethod;
+        }
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -80,13 +80,13 @@ namespace Microsoft.OData.UriParser.Aggregation
                 throw new ODataException(ODataErrorStrings.ApplyBinder_AggregateExpressionNotSingleValue(token.Expression));
             }
 
-            var typeReference = CreateAggregateExpressionTypeReference(expression, token.Method);
+            var typeReference = CreateAggregateExpressionTypeReference(expression, token.MethodDefinition);
 
             // TODO: Determine source
-            return new AggregateExpression(expression, token.Method, token.Alias, typeReference);
+            return new AggregateExpression(expression, token.MethodDefinition, token.Alias, typeReference);
         }
 
-        private IEdmTypeReference CreateAggregateExpressionTypeReference(SingleValueNode expression, AggregationMethod withVerb)
+        private IEdmTypeReference CreateAggregateExpressionTypeReference(SingleValueNode expression, AggregationMethodDefinition method)
         {
             var expressionType = expression.TypeReference;
             if (expressionType == null && aggregateExpressionsCache != null)
@@ -98,7 +98,7 @@ namespace Microsoft.OData.UriParser.Aggregation
                 }
             }
 
-            switch (withVerb)
+            switch (method.MethodKind)
             {
                 case AggregationMethod.Average:
                     var expressionPrimitiveKind = expressionType.PrimitiveKind();
@@ -125,7 +125,10 @@ namespace Microsoft.OData.UriParser.Aggregation
                 case AggregationMethod.Sum:
                     return expressionType;
                 default:
-                    throw new ODataException(ODataErrorStrings.ApplyBinder_UnsupportedAggregateMethod(withVerb));
+                    // Only the EdmModel knows which type the custom aggregation methods returns.
+                    // Since we do not have a reference for it, right now we are assuming that all custom aggregation methods returns Doubles
+                    // TODO: find a appropriate way of getting the return type.
+                    return EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Double, expressionType.IsNullable);
             }
         }
 

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -116,6 +116,7 @@ namespace Microsoft.OData.UriParser.Aggregation
                                     expressionPrimitiveKind));
                     }
 
+                case AggregationMethod.VirtualPropertyCount:
                 case AggregationMethod.CountDistinct:
                     return EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Int64, false);
                 case AggregationMethod.Max:

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -118,6 +118,7 @@ namespace Microsoft.OData.UriParser.Aggregation
 
                 case AggregationMethod.VirtualPropertyCount:
                 case AggregationMethod.CountDistinct:
+                    // Issue #758: CountDistinct and $Count should return type Edm.Decimal with Scale="0" and sufficient Precision.
                     return EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Int64, false);
                 case AggregationMethod.Max:
                 case AggregationMethod.Min:

--- a/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
@@ -172,6 +172,11 @@ namespace Microsoft.OData.UriParser
                 return GeneratePropertyAccessQueryNode(singleValueParent as SingleResourceNode, property, state);
             }
 
+            if (endPathToken.Identifier == ExpressionConstants.QueryOptionCount)
+            {
+                return new CountVirtualPropertyNode();
+            }
+
             if (functionCallBinder.TryBindEndPathAsFunctionCall(endPathToken, singleValueParent, state, out boundFunction))
             {
                 return boundFunction;

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -287,11 +287,12 @@ namespace Microsoft.OData.UriParser
             var endPathExpression = expression as EndPathToken;
             AggregationMethod verb;
 
+            // e.g. aggregate($count as Count)
             if (endPathExpression != null && endPathExpression.Identifier == ExpressionConstants.QueryOptionCount)
             {
-                expression = new EndPathToken("$count", endPathExpression.NextToken);
                 verb = AggregationMethod.VirtualPropertyCount; 
             }
+            // e.g. aggregate(UnitPrice with sum as Total)
             else
             {
                 // "with" verb

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -284,9 +284,19 @@ namespace Microsoft.OData.UriParser
         {
             // expression
             var expression = this.ParseExpression();
+            var endPathExpression = expression as EndPathToken;
+            AggregationMethod verb;
 
-            // "with" verb
-            var verb = this.ParseAggregateWith();
+            if (endPathExpression != null && endPathExpression.Identifier == ExpressionConstants.QueryOptionCount)
+            {
+                expression = new EndPathToken("$count", endPathExpression.NextToken);
+                verb = AggregationMethod.VirtualPropertyCount; 
+            }
+            else
+            {
+                // "with" verb
+                verb = this.ParseAggregateWith();
+            }
 
             // "as" alias
             var alias = this.ParseAggregateAs();

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -285,13 +285,13 @@ namespace Microsoft.OData.UriParser
             // expression
             var expression = this.ParseExpression();
             var endPathExpression = expression as EndPathToken;
-            AggregationMethod verb;
+            AggregationMethodDefinition verb;
 
             // "with" verb
             if (endPathExpression != null && endPathExpression.Identifier == ExpressionConstants.QueryOptionCount)
             {
                 // e.g. aggregate($count as Count)
-                verb = AggregationMethod.VirtualPropertyCount;
+                verb = AggregationMethodDefinition.VirtualPropertyCount;
             }
             else
             {
@@ -981,7 +981,7 @@ namespace Microsoft.OData.UriParser
             return new InnerPathToken(propertyName, parent, null);
         }
 
-        private AggregationMethod ParseAggregateWith()
+        private AggregationMethodDefinition ParseAggregateWith()
         {
             if (!TokenIdentifierIs(ExpressionConstants.KeywordWith))
             {
@@ -990,30 +990,40 @@ namespace Microsoft.OData.UriParser
 
             lexer.NextToken();
 
-            AggregationMethod verb;
+            AggregationMethodDefinition verb;
+            int identifierStartPosition = lexer.CurrentToken.Position;
+            string methodLabel = lexer.ReadDottedIdentifier(false /* acceptStar */);
 
-            switch (lexer.CurrentToken.GetIdentifier())
+            switch (methodLabel)
             {
                 case ExpressionConstants.KeywordAverage:
-                    verb = AggregationMethod.Average;
+                    verb = AggregationMethodDefinition.Average;
                     break;
                 case ExpressionConstants.KeywordCountDistinct:
-                    verb = AggregationMethod.CountDistinct;
+                    verb = AggregationMethodDefinition.CountDistinct;
                     break;
                 case ExpressionConstants.KeywordMax:
-                    verb = AggregationMethod.Max;
+                    verb = AggregationMethodDefinition.Max;
                     break;
                 case ExpressionConstants.KeywordMin:
-                    verb = AggregationMethod.Min;
+                    verb = AggregationMethodDefinition.Min;
                     break;
                 case ExpressionConstants.KeywordSum:
-                    verb = AggregationMethod.Sum;
+                    verb = AggregationMethodDefinition.Sum;
                     break;
                 default:
-                    throw ParseError(ODataErrorStrings.UriQueryExpressionParser_UnrecognizedWithVerb(lexer.CurrentToken.GetIdentifier(), this.lexer.CurrentToken.Position, this.lexer.ExpressionText));
-            }
+                    if (!methodLabel.Contains(OData.ExpressionConstants.SymbolDot))
+                    {
+                        throw ParseError(
+                            ODataErrorStrings.UriQueryExpressionParser_UnrecognizedWithMethod(
+                                methodLabel,
+                                identifierStartPosition,
+                                this.lexer.ExpressionText));
+                    }
 
-            lexer.NextToken();
+                    verb = AggregationMethodDefinition.Custom(methodLabel);
+                    break;
+            }
 
             return verb;
         }

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -287,15 +287,15 @@ namespace Microsoft.OData.UriParser
             var endPathExpression = expression as EndPathToken;
             AggregationMethod verb;
 
-            // e.g. aggregate($count as Count)
+            // "with" verb
             if (endPathExpression != null && endPathExpression.Identifier == ExpressionConstants.QueryOptionCount)
             {
-                verb = AggregationMethod.VirtualPropertyCount; 
+                // e.g. aggregate($count as Count)
+                verb = AggregationMethod.VirtualPropertyCount;
             }
-            // e.g. aggregate(UnitPrice with sum as Total)
             else
             {
-                // "with" verb
+                // e.g. aggregate(UnitPrice with sum as Total)
                 verb = this.ParseAggregateWith();
             }
 

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/CountVirtualPropertyNode.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/CountVirtualPropertyNode.cs
@@ -1,25 +1,38 @@
-﻿using Microsoft.OData.Edm;
+﻿//---------------------------------------------------------------------
+// <copyright file="CountVirtualPropertyNode.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+using Microsoft.OData.Edm;
 
 namespace Microsoft.OData.UriParser
 {
     /// <summary>
-    /// Dummy class that allows virtual property $count 
+    /// Dummy class that allows virtual property $count
     /// to work like any other aggregation method.
     /// </summary>
     public sealed class CountVirtualPropertyNode : SingleValueNode
     {
-        public CountVirtualPropertyNode() { }
+        /// <summary>Constructor.</summary>
+        public CountVirtualPropertyNode()
+        {
+        }
 
+        /// <summary>Kind of the single value node.</summary>
         public override QueryNodeKind Kind
         {
             get
             {
-                return QueryNodeKind.None;
+                return QueryNodeKind.Count;
             }
         }
 
-        public override IEdmTypeReference TypeReference {
-            get {
+        /// <summary>Type returned by the $count virtual property.</summary>
+        public override IEdmTypeReference TypeReference
+        {
+            get
+            {
+                // Issue #758: CountDistinct and $Count should return type Edm.Decimal with Scale="0" and sufficient Precision.
                 return EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Int64, false);
             }
         }

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/CountVirtualPropertyNode.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/CountVirtualPropertyNode.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.OData.Edm;
+
+namespace Microsoft.OData.UriParser
+{
+    /// <summary>
+    /// Dummy class that allows virtual property $count 
+    /// to work like any other aggregation method.
+    /// </summary>
+    public sealed class CountVirtualPropertyNode : SingleValueNode
+    {
+        public CountVirtualPropertyNode() { }
+
+        public override QueryNodeKind Kind
+        {
+            get
+            {
+                return QueryNodeKind.None;
+            }
+        }
+
+        public override IEdmTypeReference TypeReference {
+            get {
+                return EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Int64, false);
+            }
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="MultiBindingTests.cs" />
     <Compile Include="NavigationPropertyOnComplexTests.cs" />
     <Compile Include="ODataValueUtilsTests.cs" />
+    <Compile Include="PropertyCacheHandlerTests.cs" />
     <Compile Include="ScenarioTests\Roundtrip\JsonReaderWriterInjectionTests.cs" />
     <Compile Include="ServiceProviderExtensionsTests.cs" />
     <Compile Include="ContainerBuilderExtensionsTests.cs" />

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/PropertyCacheHandlerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/PropertyCacheHandlerTests.cs
@@ -1,0 +1,122 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="PropertyCacheHandlerTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using Microsoft.OData.Edm;
+using Microsoft.Spatial;
+using Xunit;
+
+namespace Microsoft.OData.Tests
+{
+    /// <summary>
+    /// This is a test class for PropertyCacheHandle and is intended
+    /// to contain all PropertyCacheHandle Unit Tests
+    ///</summary>
+    public class PropertyCacheHandlerTests
+    {
+        [Fact]
+        public void PropertyHandlerGetProperty()
+        {
+            // Model with a single entity type
+            EdmModel model = new EdmModel();
+            const string defaultNamespaceName = "Test";
+            var int32TypeRef = EdmCoreModel.Instance.GetInt32(isNullable: false);
+
+            // Create a complext type.
+            var complexType = new EdmComplexType(defaultNamespaceName, "ComplexType");
+            complexType.AddStructuralProperty("IntProp", int32TypeRef);
+            complexType.AddStructuralProperty("StringProp", EdmCoreModel.Instance.GetString(isNullable: false));
+            complexType.AddStructuralProperty("ComplexProp", new EdmComplexTypeReference(complexType, isNullable: true));
+            model.AddElement(complexType);
+
+            // Create an entity with a complex type property.
+            var singleComplexPropertyEntityType = new EdmEntityType(defaultNamespaceName, "SingleComplexPropertyEntityType");
+            singleComplexPropertyEntityType.AddKeys(singleComplexPropertyEntityType.AddStructuralProperty("ID", int32TypeRef));
+            singleComplexPropertyEntityType.AddStructuralProperty("ComplexProp", new EdmComplexTypeReference(complexType, isNullable: true));
+            model.AddElement(singleComplexPropertyEntityType);
+
+            // Create a property handler and enter a resource set scope.
+            PropertyCacheHandler handler = new PropertyCacheHandler();
+            handler.EnterResourceSetScope(singleComplexPropertyEntityType, 0);
+
+            // Create a PropertySerializationInfo for ComplexProp.IntProp
+            var info1 = handler.GetProperty("IntProp", complexType);
+            info1.Should().NotBeNull();
+
+            // Get a second PropertySerializationInfo for ComplexProp.IntProp; it should be the same.
+            PropertySerializationInfo info2 = handler.GetProperty("IntProp", complexType);
+            info2.Should().NotBeNull();
+            info2.Should().BeSameAs(info1);
+        }
+
+        [Fact]
+        public void PropertyHandlerGetPropertyNullOwningType()
+        {
+            // Model with a single entity type
+            EdmModel model = new EdmModel();
+            const string defaultNamespaceName = "Test";
+            var int32TypeRef = EdmCoreModel.Instance.GetInt32(isNullable: false);
+
+            // Create an entity with a complex type property.
+            var singleComplexPropertyEntityType = new EdmEntityType(defaultNamespaceName, "SingleComplexPropertyEntityType");
+            singleComplexPropertyEntityType.AddKeys(singleComplexPropertyEntityType.AddStructuralProperty("ID", int32TypeRef));
+            model.AddElement(singleComplexPropertyEntityType);
+
+            // Create a property handler and enter a resource set scope.
+            PropertyCacheHandler handler = new PropertyCacheHandler();
+            handler.EnterResourceSetScope(singleComplexPropertyEntityType, 0);
+
+            // Create a PropertySerializationInfo for ComplexProp.IntProp
+            var info1 = handler.GetProperty("IntProp", null);
+            info1.Should().NotBeNull();
+
+            // Get a second PropertySerializationInfo for ComplexProp.IntProp; it should be the same.
+            PropertySerializationInfo info2 = handler.GetProperty("IntProp", null);
+            info2.Should().NotBeNull();
+            info2.Should().BeSameAs(info1);
+        }
+
+        [Fact]
+        public void PropertyHandlerGetPropertyNameCollision()
+        {
+            // Model with a single entity type
+            EdmModel model = new EdmModel();
+            const string defaultNamespaceName = "Test";
+            var int32TypeRef = EdmCoreModel.Instance.GetInt32(isNullable: false);
+
+            // Create a complext types.
+            var complexType1 = new EdmComplexType(defaultNamespaceName, "ComplexType1");
+            complexType1.AddStructuralProperty("Prop1", int32TypeRef);
+            model.AddElement(complexType1);
+
+            var complexType2 = new EdmComplexType(defaultNamespaceName, "ComplexType2");
+            complexType1.AddStructuralProperty("Prop1", EdmCoreModel.Instance.GetString(isNullable: false));
+            model.AddElement(complexType2);
+
+            // Create an entity with a complex type property.
+            var singleComplexPropertyEntityType = new EdmEntityType(defaultNamespaceName, "SingleComplexPropertyEntityType");
+            singleComplexPropertyEntityType.AddKeys(singleComplexPropertyEntityType.AddStructuralProperty("ID", int32TypeRef));
+            singleComplexPropertyEntityType.AddStructuralProperty("ComplexProp1", new EdmComplexTypeReference(complexType1, isNullable: true));
+            singleComplexPropertyEntityType.AddStructuralProperty("ComplexProp2", new EdmComplexTypeReference(complexType2, isNullable: true));
+            model.AddElement(singleComplexPropertyEntityType);
+
+            // Create a property handler and enter a resource set scope.
+            PropertyCacheHandler handler = new PropertyCacheHandler();
+            handler.EnterResourceSetScope(singleComplexPropertyEntityType, 0);
+
+            // Create a PropertySerializationInfo for ComplexProp1.Prop1
+            var info1 = handler.GetProperty("Prop1", complexType1);
+            info1.Should().NotBeNull();
+
+            // Create a PropertySerializationInfo for ComplexProp2.Prop1; they shoudl be different.
+            var info2 = handler.GetProperty("Prop1", complexType2);
+            info2.Should().NotBeNull();
+            info2.Should().NotBeSameAs(info1);
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
@@ -66,6 +66,32 @@ namespace Microsoft.OData.Tests.UriParser.Extensions.Binders
         }
 
         [Fact]
+        public void BindApplyWithCountInAggregateShouldReturnApplyClause()
+        {
+            var tokens = _parser.ParseApply("aggregate($count as TotalCount)");
+
+            var binder = new ApplyBinder(FakeBindMethods.BindSingleComplexProperty, _bindingState);
+            var actual = binder.BindApply(tokens);
+
+            actual.Should().NotBeNull();
+            actual.Transformations.Should().HaveCount(1);
+
+            var transformations = actual.Transformations.ToList();
+            var aggregate = transformations[0] as AggregateTransformationNode;
+
+            aggregate.Should().NotBeNull();
+            aggregate.Kind.Should().Be(TransformationNodeKind.Aggregate);
+            aggregate.Expressions.Should().NotBeNull();
+            aggregate.Expressions.Should().HaveCount(1);
+
+            var statements = aggregate.Expressions.ToList();
+            var statement = statements[0];
+
+            statement.Method.Should().Be(AggregationMethod.VirtualPropertyCount);
+            statement.Alias.Should().Be("TotalCount");
+        }
+
+        [Fact]
         public void BindApplyWithAggregateAndFilterShouldReturnApplyClause()
         {
             var tokens = _parser.ParseApply("aggregate(StockQuantity with sum as TotalPrice)/filter(TotalPrice eq 100)");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/SyntacticAst/AggregateExpressionTokenTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/SyntacticAst/AggregateExpressionTokenTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.OData.Tests.UriParser.Extensions.SyntacticAst
         }
 
         [Fact]
-        public void WithVerbSetCorrectly()
+        public void WithMethodSetCorrectly()
         {
             var token = new AggregateExpressionToken(expressionToken, AggregationMethod.CountDistinct, "Alias");
             token.Method.Should().Be(AggregationMethod.CountDistinct);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
@@ -165,6 +165,41 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         }
 
         [Fact]
+        public void ParseApplyWithSingleCountExpressionShouldReturnAggregateToken()
+        {
+            var apply = "aggregate($count as Count)";
+
+            var actual = this.testSubject.ParseApply(apply);
+            actual.Should().NotBeNull();
+            actual.Should().HaveCount(1);
+
+            var aggregate = actual.First() as AggregateToken;
+            aggregate.Should().NotBeNull();
+            aggregate.Expressions.Should().HaveCount(1);
+
+            VerifyAggregateExpressionToken("$count", AggregationMethod.VirtualPropertyCount, "Count", aggregate.Expressions.First());
+        }
+
+        [Fact]
+        public void ParseApplyWithCountAndOtherAggregationExpressionShouldReturnAggregateToken()
+        {
+            var apply = "aggregate($count as Count, SharePrice with countdistinct as SharePriceDistinctCount)";
+
+            var actual = this.testSubject.ParseApply(apply);
+            actual.Should().NotBeNull();
+            actual.Should().HaveCount(1);
+
+            var aggregate = actual.First() as AggregateToken;
+            aggregate.Should().NotBeNull();
+            aggregate.Expressions.Should().HaveCount(2);
+
+            var statements = aggregate.Expressions.ToList();
+            
+            VerifyAggregateExpressionToken("$count", AggregationMethod.VirtualPropertyCount, "Count", aggregate.Expressions.First());
+            VerifyAggregateExpressionToken("SharePrice", AggregationMethod.CountDistinct, "SharePriceDistinctCount", statements[1]);        
+        }
+
+        [Fact]
         public void ParseApplyWithAggregateMissingOpenParenShouldThrow()
         {
             var apply = "aggregate UnitPrice with sum as TotalPrice)";

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
@@ -181,6 +181,15 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         }
 
         [Fact]
+        public void ParseApplyWithSingleCountExpressionCannotHaveWithKeyWord()
+        {
+            var apply = "aggregate($count with sum as Count)";
+
+            Action parse = () => this.testSubject.ParseApply(apply);
+            parse.ShouldThrow<ODataException>().Where(e => e.Message == ErrorStrings.UriQueryExpressionParser_AsExpected(17, apply));
+        }
+
+        [Fact]
         public void ParseApplyWithCountAndOtherAggregationExpressionShouldReturnAggregateToken()
         {
             var apply = "aggregate($count as Count, SharePrice with countdistinct as SharePriceDistinctCount)";

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Visitors/SyntacticTreeVisitorTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Visitors/SyntacticTreeVisitorTests.cs
@@ -153,7 +153,7 @@ namespace Microsoft.OData.Tests.UriParser.Visitors
         public void AggregateExpressionOperatorNotImplemented()
         {
             FakeVisitor visitor = new FakeVisitor();
-            Action visitUnaryOperatorToken = () => visitor.Visit(new AggregateExpressionToken(new EndPathToken("Identifier", null), AggregationMethod.Sum, "Alias"));
+            Action visitUnaryOperatorToken = () => visitor.Visit(new AggregateExpressionToken(new EndPathToken("Identifier", null), AggregationMethodDefinition.Sum, "Alias"));
             visitUnaryOperatorToken.ShouldThrow<NotImplementedException>();
         }
 

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -5683,6 +5683,13 @@ public sealed class Microsoft.OData.UriParser.CountSegment : Microsoft.OData.Uri
 	public virtual T TranslateWith (PathSegmentTranslator`1 translator)
 }
 
+public sealed class Microsoft.OData.UriParser.CountVirtualPropertyNode : Microsoft.OData.UriParser.SingleValueNode {
+	public CountVirtualPropertyNode ()
+
+	Microsoft.OData.UriParser.QueryNodeKind Kind  { public virtual get; }
+	Microsoft.OData.Edm.IEdmTypeReference TypeReference  { public virtual get; }
+}
+
 public sealed class Microsoft.OData.UriParser.CustomUriLiteralParsers : IUriLiteralParser {
 	public static void AddCustomUriLiteralParser (Microsoft.OData.UriParser.IUriLiteralParser customUriLiteralParser)
 	public static void AddCustomUriLiteralParser (Microsoft.OData.Edm.IEdmTypeReference edmTypeReference, Microsoft.OData.UriParser.IUriLiteralParser customUriLiteralParser)
@@ -6154,6 +6161,7 @@ public enum Microsoft.OData.UriParser.Aggregation.AggregationMethod : int {
 	Max = 2
 	Min = 1
 	Sum = 0
+	VirtualPropertyCount = 5
 }
 
 public enum Microsoft.OData.UriParser.Aggregation.TransformationNodeKind : int {

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -6158,6 +6158,7 @@ public sealed class Microsoft.OData.UriParser.WildcardSelectItem : Microsoft.ODa
 public enum Microsoft.OData.UriParser.Aggregation.AggregationMethod : int {
 	Average = 3
 	CountDistinct = 4
+	Custom = 6
 	Max = 2
 	Min = 1
 	Sum = 0
@@ -6178,10 +6179,12 @@ public abstract class Microsoft.OData.UriParser.Aggregation.TransformationNode {
 
 public sealed class Microsoft.OData.UriParser.Aggregation.AggregateExpression {
 	public AggregateExpression (Microsoft.OData.UriParser.SingleValueNode expression, Microsoft.OData.UriParser.Aggregation.AggregationMethod method, string alias, Microsoft.OData.Edm.IEdmTypeReference typeReference)
+	public AggregateExpression (Microsoft.OData.UriParser.SingleValueNode expression, Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition methodDefinition, string alias, Microsoft.OData.Edm.IEdmTypeReference typeReference)
 
 	string Alias  { public get; }
 	Microsoft.OData.UriParser.SingleValueNode Expression  { public get; }
 	Microsoft.OData.UriParser.Aggregation.AggregationMethod Method  { public get; }
+	Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition MethodDefinition  { public get; }
 	Microsoft.OData.Edm.IEdmTypeReference TypeReference  { public get; }
 }
 
@@ -6190,6 +6193,20 @@ public sealed class Microsoft.OData.UriParser.Aggregation.AggregateTransformatio
 
 	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.Aggregation.AggregateExpression]] Expressions  { public get; }
 	Microsoft.OData.UriParser.Aggregation.TransformationNodeKind Kind  { public virtual get; }
+}
+
+public sealed class Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition {
+	public static Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition Average = Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition
+	public static Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition CountDistinct = Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition
+	public static Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition Max = Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition
+	public static Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition Min = Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition
+	public static Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition Sum = Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition
+	public static Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition VirtualPropertyCount = Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition
+
+	Microsoft.OData.UriParser.Aggregation.AggregationMethod MethodKind  { public get; }
+	string MethodLabel  { public get; }
+
+	public static Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition Custom (string customMethodLabel)
 }
 
 public sealed class Microsoft.OData.UriParser.Aggregation.ApplyClause {


### PR DESCRIPTION
### Description
*Enhancing AggregationMethod class and modifying UriQueryExpressionParser to support Custom Aggregation Methods according to OData 4.0 spec. Right now only methods that return doubles are supported*

### Checklist (Uncheck if it is not completed)
- [x] Test cases added
- [x] VS Build and tests passed

### Observations 
*We need to find out the best way to address the TODOs in the code. In the return type of the aggregation methods: right now we are limited to methods that returns doubles, because the parses don't have information about the functions registered.*